### PR TITLE
Properly skip compiling this file when TFM is .NET 5 or newer.

### DIFF
--- a/SkipLocalsInitAttribute.Sources/SkipLocalsInitAttribute.cs
+++ b/SkipLocalsInitAttribute.Sources/SkipLocalsInitAttribute.cs
@@ -1,3 +1,4 @@
+#if !NET5_0_OR_GREATER
 namespace System.Runtime.CompilerServices
 {
     [AttributeUsage(
@@ -17,3 +18,4 @@ namespace System.Runtime.CompilerServices
         }
     }
 }
+#endif


### PR DESCRIPTION
People using .NET 6 and ns2.0 will be bitten by this when the attribute is already built into the BCL.